### PR TITLE
Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Subworkflow: Busco Diamond
 Subworkflow: Collate Stats
 
 1. Count BUSCO genes
+2. Combine output of mosdepth and count_busco_genes
 
 ## Quick Start
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -28,6 +28,14 @@ process {
         ]
     }
 
+    withName: '.*:.*:COLLATE_STATS:COVERAGE_TSV' {
+        publishDir = [
+            path: { "${params.outdir}/blobtoolkit" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: '.*.*:BUSCO_DIAMOND:GOAT_TAXONSEARCH|BUSCO|EXTRACT_BUSCO_GENES|DIAMOND_BLASTP' {
         publishDir = [
             path: { "${params.outdir}/blobtoolkit/busco_diamond" },

--- a/docs/output.md
+++ b/docs/output.md
@@ -30,6 +30,7 @@ blobtoolkit
   ├── mMelMel1_T1.regions.bed.gz
   ├── mMelMel1_T1.regions.bed.gz.csi
   ├── GCA_922984935.2.subset_busco_genes_count.tsv
+  ├── GCA_922984935.2.subset_coverage.tsv
 ```
 
 - `*.mosdepth.global.dist.txt` and `*.mosdepth.region.dist.txt` : Text files with global and region cumulative coverage distribution respectively

--- a/docs/output.md
+++ b/docs/output.md
@@ -37,6 +37,7 @@ blobtoolkit
 - `*.per-base.bed.gz` and `*.per-base.bed.gz.csi` : BED file with per-base coverage and it's index file
 - `*.regions.bed.gz` and `*.regions.bed.gz.csi` : BED file with per-region coverage and it's index file
 - `*_busco_genes_count.tsv` : TSV file counting BUSCOs for different lineages across BED file
+- `*_coverage.tsv` : TSV file combining the BED file with per-region coverage from mosdepth and the busco_count_genes TSV file
 
 ### Blast Analysis Files
 

--- a/modules/local/coverage_tsv.nf
+++ b/modules/local/coverage_tsv.nf
@@ -1,0 +1,32 @@
+process COVERAGE_TSV {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'ubuntu:20.04' }"
+
+    input:
+    tuple val(meta), path(mosdepth)         //taking output of mosdepth
+    tuple val(meta), path(countbusogenes)   //taking output of count_buscogenes
+
+    output:
+    tuple val(meta), path ('*_coverage.tsv')       , emit: cov_tsv
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    sed -i 1i"Sequence  Start   End ${prefix}_cov" ${mosdepth}
+    paste ${countbusogenes} ${mosdepth} > ${prefix}_coverage.tsv
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        coverage_tsv : 1.00
+    END_VERSIONS
+    """
+}

--- a/subworkflows/local/collate_stats.nf
+++ b/subworkflows/local/collate_stats.nf
@@ -1,9 +1,13 @@
 include { COUNT_BUSCO_GENES    } from '../../modules/local/count_busco_genes'
+include { GUNZIP               } from '../../modules/nf-core/gunzip/main'
+include { COVERAGE_TSV         } from '../../modules/local/coverage_tsv'
+
 
 workflow COLLATE_STATS {
     take: 
     busco_dir       // channel: [val(meta), path(busco_dir)]
     bed             // channel: [val(meta), path(bed)]
+    regions_bed     // channel: [val(meta), path(regions_bed)]
 
     main:
     ch_versions = Channel.empty()
@@ -17,7 +21,12 @@ workflow COLLATE_STATS {
     COUNT_BUSCO_GENES(ch_tsv_path, bed)
     ch_versions = ch_versions.mix(COUNT_BUSCO_GENES.out.versions)
 
+    // Combine output TSV from mosdepth and count_busco_genes
+    COVERAGE_TSV(GUNZIP(regions_bed).gunzip, COUNT_BUSCO_GENES.out.tsv)
+    ch_versions = ch_versions.mix(COVERAGE_TSV.out.versions)
+
     emit:
     count_genes = COUNT_BUSCO_GENES.out.tsv
+    cov_tsv = COVERAGE_TSV.out.cov_tsv
     versions = ch_versions
 }

--- a/workflows/blobtoolkit.nf
+++ b/workflows/blobtoolkit.nf
@@ -87,7 +87,7 @@ workflow BLOBTOOLKIT {
     //
     // SUBWORKFLOW: Count BUSCO genes   
     //
-    COLLATE_STATS(BUSCO_DIAMOND.out.busco_dir, COVERAGE_STATS.out.fw_bed)
+    COLLATE_STATS(BUSCO_DIAMOND.out.busco_dir, COVERAGE_STATS.out.fw_bed, COVERAGE_STATS.out.regions_bed)
     ch_versions = ch_versions.mix(COLLATE_STATS.out.versions)
 
     //


### PR DESCRIPTION
## coverage_tsv module

This PR implements the coverage_TSV which combines the TSV files output by mosdepth and count_busco_genes and also integrates it into the workflow. GitHub CI not working because files needed for BUSCO are on lustre.

<!--
# nf-core/blobtoolkit pull request

Many thanks for contributing to nf-core/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/blobtoolkit/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
