### PR TITLE
window_stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Subworkflow: Collate Stats
 
 1. Count BUSCO genes
 2. Combine output of mosdepth and count_busco_genes
+3. Aggregate 1kb values into windows of fixed proportion (10%, 1% of contig length) and fixed length (100kb, 1Mb)
 
 ## Quick Start
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -76,4 +76,13 @@ process {
         ext.args = '--evalue 1.0e-25  --max-target-seqs 10 --max-hsps 1'
     }
 
+    withName: 'GET_WINDOW_STATS' {
+        publishDir = [
+            path: { "${params.outdir}/blobtoolkit" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = '--window 0.1 --window 0.01 --window 100000 --window 1000000'
+    }
+
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -31,6 +31,10 @@ blobtoolkit
   ├── mMelMel1_T1.regions.bed.gz.csi
   ├── GCA_922984935.2.subset_busco_genes_count.tsv
   ├── GCA_922984935.2.subset_coverage.tsv
+  |── GCA_922984935.2.subset_window_stats.0.1.tsv
+  |── GCA_922984935.2.subset_window_stats.0.01.tsv
+  |── GCA_922984935.2.subset_window_stats.100000.tsv
+  |── GCA_922984935.2.subset_window_stats.1000000.tsv
 ```
 
 - `*.mosdepth.global.dist.txt` and `*.mosdepth.region.dist.txt` : Text files with global and region cumulative coverage distribution respectively
@@ -39,6 +43,10 @@ blobtoolkit
 - `*.regions.bed.gz` and `*.regions.bed.gz.csi` : BED file with per-region coverage and it's index file
 - `*_busco_genes_count.tsv` : TSV file counting BUSCOs for different lineages across BED file
 - `*_coverage.tsv` : TSV file combining the BED file with per-region coverage from mosdepth and the busco_count_genes TSV file
+- `*_window_stats.0.1.tsv` : Aggregate 1kb windows into a window of 10% of the contig length
+- `*_window_stats.0.01.tsv` : Aggregate 1kb windows into a window of 1% of the contig length
+- `*_window_stats.100000.tsv` : Aggregate 1kb windows into 100kb windows
+- `*_window_stats.1000000.tsv` : Aggregate 1kb windows into 1Mb windows
 
 ### Blast Analysis Files
 

--- a/modules/local/coverage_tsv.nf
+++ b/modules/local/coverage_tsv.nf
@@ -22,11 +22,13 @@ process COVERAGE_TSV {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    sed -i 1i"Sequence  Start   End ${prefix}_cov" ${mosdepth}
-    paste ${countbusogenes} ${mosdepth} > ${prefix}_coverage.tsv
+    cut -f 4 ${mosdepth} > temp1 
+    sed -i 1i"${prefix}_cov" temp1
+    paste ${countbusogenes} temp1 > ${prefix}_coverage.tsv
+    
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        coverage_tsv : 1.00
+        coverage_tsv : 1.10
     END_VERSIONS
     """
 }

--- a/modules/local/get_window_stats.nf
+++ b/modules/local/get_window_stats.nf
@@ -1,0 +1,33 @@
+process GET_WINDOW_STATS {
+    tag "$meta.id"
+    label 'process_single'
+
+    if (params.enable_conda) {
+        exit 1, "Conda environments cannot be used when using the GET_WINDOW_STATS module. Please use docker or singularity containers."
+    }
+    container "genomehubs/blobtoolkit-blobtools:3.3.4"
+
+    input:
+    tuple val(meta), path(tsv)  
+
+    output:
+    tuple val(meta), path('*_window_stats*.tsv') , emit: tsv
+    path "versions.yml"                          , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    btk pipeline window-stats \\
+            --in ${tsv} \\
+            $args \\
+            --out ${prefix}_window_stats.tsv
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        blobtoolkit: \$(btk --version | cut -d' ' -f2 | sed 's/v//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/get_window_stats.nf
+++ b/modules/local/get_window_stats.nf
@@ -5,7 +5,7 @@ process GET_WINDOW_STATS {
     if (params.enable_conda) {
         exit 1, "Conda environments cannot be used when using the GET_WINDOW_STATS module. Please use docker or singularity containers."
     }
-    container "genomehubs/blobtoolkit-blobtools:3.3.4"
+    container "genomehubs/blobtoolkit-blobtools:3.5.4"
 
     input:
     tuple val(meta), path(tsv)  

--- a/subworkflows/local/collate_stats.nf
+++ b/subworkflows/local/collate_stats.nf
@@ -1,6 +1,7 @@
 include { COUNT_BUSCO_GENES    } from '../../modules/local/count_busco_genes'
 include { GUNZIP               } from '../../modules/nf-core/gunzip/main'
 include { COVERAGE_TSV         } from '../../modules/local/coverage_tsv'
+include { GET_WINDOW_STATS     } from '../../modules/local/get_window_stats'
 
 
 workflow COLLATE_STATS {
@@ -24,6 +25,9 @@ workflow COLLATE_STATS {
     // Combine output TSV from mosdepth and count_busco_genes
     COVERAGE_TSV(GUNZIP(regions_bed).gunzip, COUNT_BUSCO_GENES.out.tsv)
     ch_versions = ch_versions.mix(COVERAGE_TSV.out.versions)
+
+    GET_WINDOW_STATS(COVERAGE_TSV.out.cov_tsv)
+    ch_versions = ch_versions.mix(GET_WINDOW_STATS.out.versions)
 
     emit:
     count_genes = COUNT_BUSCO_GENES.out.tsv


### PR DESCRIPTION
Implemented and integrated the `window_stats` module into the pipeline. Modified the `coverage_tsv` module as the `coverage.tsv` file generated by it was breaking the `window-stats` python script being called as it wasn't expecting the sequence to be repeated in the file. 

<!--
# nf-core/blobtoolkit pull request

Many thanks for contributing to nf-core/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/blobtoolkit/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
