### PR TITLE
Basal lineage configuration

### DIFF
--- a/modules/local/blobtoolkit/extractbuscos.nf
+++ b/modules/local/blobtoolkit/extractbuscos.nf
@@ -9,9 +9,7 @@ process BLOBTOOLKIT_EXTRACTBUSCOS {
 
     input:
     tuple val(meta), path(fasta)
-    tuple val(meta1), path(seq1, stageAs: "lineage1/*")
-    tuple val(meta2), path(seq2, stageAs: "lineage2/*")
-    tuple val(meta3), path(seq3, stageAs: "lineage3/*")
+    tuple val(metaseq), path(seq, stageAs: "lineage??/*")
 
     output:
     tuple val(meta), path("*_buscogenes.fasta"), emit: genes
@@ -23,11 +21,10 @@ process BLOBTOOLKIT_EXTRACTBUSCOS {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def seq_args = seq.collect { "--busco " + it } .join(' ')
     """
     btk pipeline extract-busco-genes \\
-        --busco $seq1 \\
-        --busco $seq2 \\
-        --busco $seq3 \\
+        $seq_args \\
         --out ${prefix}_buscogenes.fasta
 
     cat <<-END_VERSIONS > versions.yml

--- a/subworkflows/local/busco_diamond_blastp.nf
+++ b/subworkflows/local/busco_diamond_blastp.nf
@@ -35,7 +35,13 @@ workflow BUSCO_DIAMOND {
     GOAT_TAXONSEARCH.out.taxonsearch
     | map { meta, csv -> csv.splitCsv(header:true, sep:'\t', strip:true) }
     | map { row -> row.odb10_lineage.findAll { it != "" } }
-    | map { lineages -> [ lineages + [ "bacteria_odb10", "archaea_odb10" ] ] }
+    | set { ch_ancestral_lineages }
+
+
+    // Add the basal lineages to the list (excluding duplicates)
+    basal_lineages = [ "archaea_odb10", "bacteria_odb10", "eukaryota_odb10" ]
+    ch_ancestral_lineages
+    | map { lineages -> (lineages + basal_lineages).unique() }
     | flatten ()
     | set { ch_lineages }
 
@@ -47,18 +53,13 @@ workflow BUSCO_DIAMOND {
     // Select input for BLOBTOOLKIT_EXTRACTBUSCOS
     //
     BUSCO.out.seq_dir
-    | map { meta, seq -> [ [ "id": seq.parent.baseName ], seq ] }
-    | branch {
-        meta, seq ->
-            archaea   : meta.id == "run_archaea_odb10"
-            bacteria  : meta.id == "run_bacteria_odb10"
-            eukaryota : meta.id == "run_eukaryota_odb10"
-    }
-    | set { ch_busco }
+    | filter { meta, seq -> basal_lineages.contains(seq.parent.baseName.minus("run_")) }
+    | groupTuple()
+    | set { ch_basal_buscos }
 
 
-    // Extract BUSCO genes from the 3 kingdoms
-    BLOBTOOLKIT_EXTRACTBUSCOS ( fasta, ch_busco.archaea, ch_busco.bacteria, ch_busco.eukaryota )
+    // Extract BUSCO genes from the basal lineages
+    BLOBTOOLKIT_EXTRACTBUSCOS ( fasta, ch_basal_buscos )
     ch_versions = ch_versions.mix ( BLOBTOOLKIT_EXTRACTBUSCOS.out.versions.first() )
 
 


### PR DESCRIPTION
As I was playing the Yaml config file, I found a way of defining the "basal" Busco lineages as an actual parameter. Not only it paves the way for connecting the sub-workflow to the config file, I think it makes the code easier to maintain as:
1. the module doesn't have to know how many basal lineages there are.
2. the sub-workflow will not need to hardcode the lineage names. It could take the list from `params.basal_lineages`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
