### PR TITLE
Pipeline configuration with a Yaml file

### DIFF
--- a/assets/config.yaml
+++ b/assets/config.yaml
@@ -1,0 +1,82 @@
+assembly:
+  accession: GCA_922984935.2
+  alias: mMelMel3.2 paternal haplotype
+  bioproject: PRJEB49353
+  biosample: SAMEA7524400
+  file: /lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz
+  level: chromosome
+  prefix: CAKLPM02
+  scaffold-count: 538
+  span: 2738694574
+  url: ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/922/984/935/GCA_922984935.2_mMelMel3.2_paternal_haplotype/GCA_922984935.2_mMelMel3.2_paternal_haplotype_genomic.fna.gz
+busco:
+  basal_lineages:
+  - eukaryota_odb10
+  - bacteria_odb10
+  - archaea_odb10
+  download_dir: /lustre/scratch123/tol/resources/nextflow/busco_2021_06_reduced/
+  lineages:
+  - carnivora_odb10
+  - laurasiatheria_odb10
+  - eutheria_odb10
+  - mammalia_odb10
+  - tetrapoda_odb10
+  - vertebrata_odb10
+  - metazoa_odb10
+  - eukaryota_odb10
+#fields:
+#  categories:
+#    file: ./GCA_922984935.2/assembly/GCA_922984935.2.categories.tsv
+#  synonyms:
+#    file: ./GCA_922984935.2/assembly/GCA_922984935.2.synonyms.tsv
+#    prefix: insdc
+#reads:
+#  coverage:
+#    max: 30
+#  paired: []
+#  single:
+#  - base_count: 27436689772
+#    file: /blobtoolkit/datasets/GCA_949316205.1/reads/ERR10879948.fastq.gz
+#    platform: PACBIO_SMRT
+#    prefix: ERR10879948
+#    url: ftp.sra.ebi.ac.uk/vol1/fastq/ERR108/048/ERR10879948/ERR10879948.fastq.gz
+settings:
+  blast_chunk: 100000
+  blast_max_chunks: 10
+  blast_min_length: 1000
+  blast_overlap: 0
+  stats_chunk: 1000
+  stats_windows:
+  - 0.1
+  - 0.01
+  - 100000
+  - 1000000
+  taxdump: /lustre/scratch123/tol/teams/grit/geval_pipeline/btk_databases/taxdump
+  tmp: /tmp
+similarity:
+  blastn:
+    name: nt
+    path: /blobtoolkit/databases/nt_2021_06
+  defaults:
+    evalue: 1.0e-10
+    import_evalue: 1.0e-25
+    max_target_seqs: 10
+    taxrule: buscogenes
+  diamond_blastp:
+    import_max_target_seqs: 100000
+    name: reference_proteomes
+    path: /blobtoolkit/databases/uniprot_2021_06
+    taxrule: blastp=buscogenes
+  diamond_blastx:
+    name: reference_proteomes
+    path: /blobtoolkit/databases/uniprot_2021_06
+taxon:
+  class: Mammalia
+  family: Mustelidae
+  genus: Meles
+  kingdom: Metazoa
+  name: Meles meles
+  order: Carnivora
+  phylum: Chordata
+  superkingdom: Eukaryota
+  taxid: '9662'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -38,7 +38,9 @@ process {
     }
 
     withName: "BLOBTOOLKIT_WINDOWSTATS" {
-        ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000"
+        ext.args = {
+            params.settings.stats_windows.collect { "--window " + it } .join(' ')
+        }
     }
 
     withName: "BLOBTOOLKIT_BLOBDIR" {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -34,7 +34,11 @@ process {
     }
 
     withName: "DIAMOND_BLASTP" {
-        ext.args = "--evalue 1.0e-25  --max-target-seqs 10 --max-hsps 1"
+        ext.args = {
+            "--evalue ${-> params.similarity.diamond_blastp.import_evalue ?: params.similarity.defaults.import_evalue } " +
+            "--max-target-seqs ${-> params.similarity.diamond_blastp.max_target_seqs ?: params.similarity.defaults.max_target_seqs } " +
+            "--max-hsps 1"
+        }
     }
 
     withName: "BLOBTOOLKIT_WINDOWSTATS" {

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,11 +24,6 @@ params {
     // Give any required params for the test so that command line flags are not needed
     input     = "${projectDir}/assets/test/samplesheet.csv"
 
-    // Fasta references
-    fasta     = "/lustre/scratch123/tol/resources/nextflow/test-data/Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz"
-    accession = "GCA_922984935.2"
-    taxon     = "Meles meles"
-
     // Databases
     uniprot   = "${projectDir}/assets/test/mCerEla1.1.buscogenes.dmnd"
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -31,6 +31,5 @@ params {
 
     // Databases
     taxdump   = "/lustre/scratch123/tol/teams/grit/geval_pipeline/btk_databases/taxdump"
-    busco     = "/lustre/scratch123/tol/resources/nextflow/busco_2021_06_reduced/"
     uniprot   = "${projectDir}/assets/test/mCerEla1.1.buscogenes.dmnd"
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -30,6 +30,5 @@ params {
     taxon     = "Meles meles"
 
     // Databases
-    taxdump   = "/lustre/scratch123/tol/teams/grit/geval_pipeline/btk_databases/taxdump"
     uniprot   = "${projectDir}/assets/test/mCerEla1.1.buscogenes.dmnd"
 }

--- a/lib/WorkflowBlobtoolkit.groovy
+++ b/lib/WorkflowBlobtoolkit.groovy
@@ -12,9 +12,6 @@ class WorkflowBlobtoolkit {
     //
     public static void initialise(params, log) {
 
-        if (!params.fasta) {
-            Nextflow.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
-        }
     }
 
     //

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -49,31 +49,6 @@
                 }
             }
         },
-        "reference_genome_options": {
-            "title": "Reference genome options",
-            "type": "object",
-            "fa_icon": "fas fa-dna",
-            "description": "Reference genome related files and options required for the workflow.",
-            "required": ["taxon", "accession", "fasta"],
-            "properties": {
-                "taxon": {
-                    "type": "string",
-                    "description": "NCBI taxonomy ID for the genome species"
-                },
-                "accession": {
-                    "type": "string",
-                    "description": "Genome accession where available or an identifier for draft assemblies"
-                },
-                "fasta": {
-                    "type": "string",
-                    "format": "file-path",
-                    "mimetype": "text/plain",
-                    "pattern": "^\\S+\\.fn?a(sta)?(\\.gz)?$",
-                    "description": "Path to FASTA genome file.",
-                    "fa_icon": "far fa-file-code"
-                }
-            }
-        },
         "databases": {
             "title": "Databases",
             "type": "object",
@@ -292,9 +267,6 @@
     "allOf": [
         {
             "$ref": "#/definitions/input_output_options"
-        },
-        {
-            "$ref": "#/definitions/reference_genome_options"
         },
         {
             "$ref": "#/definitions/databases"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -79,7 +79,7 @@
             "type": "object",
             "fa_icon": "fas fa-database",
             "description": "Define the location and parameters to work with databases.",
-            "required": ["uniprot", "taxdump"],
+            "required": ["uniprot"],
             "properties": {
                 "blastp_cols": {
                     "type": "string",
@@ -99,12 +99,6 @@
                     "pattern": "^\\S+\\.dmnd$",
                     "description": "Path to the Diamond species-specific buscogenes database",
                     "fa_icon": "fas fa-file-archive"
-                },
-                "taxdump": {
-                    "type": "string",
-                    "format": "directory-path",
-                    "description": "Path to the new NCBI tax dump database",
-                    "fa_icon": "fas fa-folder-open"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -81,19 +81,6 @@
             "description": "Define the location and parameters to work with databases.",
             "required": ["uniprot", "taxdump"],
             "properties": {
-                "taxa_file": {
-                    "type": "string",
-                    "format": "file-path",
-                    "description": "Path to file containing the BUSCO lineages for the genome species",
-                    "help_text": "If this file is not included, the relevant BUSCO lineages are automatically calculated using the taxon parameter.",
-                    "fa_icon": "fas fa-file-alt"
-                },
-                "busco": {
-                    "type": "string",
-                    "format": "directory-path",
-                    "description": "Local directory where clade-specific BUSCO lineage datasets are stored",
-                    "fa_icon": "fas fa-folder-open"
-                },
                 "blastp_cols": {
                     "type": "string",
                     "description": "When blastp_outext is 'txt', this is the list of columns that Diamond BLAST should print.",

--- a/subworkflows/local/busco_diamond_blastp.nf
+++ b/subworkflows/local/busco_diamond_blastp.nf
@@ -21,6 +21,9 @@ workflow BUSCO_DIAMOND {
     main:
     ch_versions = Channel.empty()
 
+    if (params.busco.lineages) {
+        ch_ancestral_lineages = Channel.of( params.busco.lineages )
+    } else {
 
     //
     // Fetch BUSCO lineages for taxon (or taxa)
@@ -37,11 +40,11 @@ workflow BUSCO_DIAMOND {
     | map { row -> row.odb10_lineage.findAll { it != "" } }
     | set { ch_ancestral_lineages }
 
+    }
 
     // Add the basal lineages to the list (excluding duplicates)
-    basal_lineages = [ "archaea_odb10", "bacteria_odb10", "eukaryota_odb10" ]
     ch_ancestral_lineages
-    | map { lineages -> (lineages + basal_lineages).unique() }
+    | map { lineages -> (lineages + params.busco.basal_lineages).unique() }
     | flatten ()
     | set { ch_lineages }
 

--- a/workflows/blobtoolkit.nf
+++ b/workflows/blobtoolkit.nf
@@ -11,7 +11,7 @@ WorkflowBlobtoolkit.initialise(params, log)
 
 // Add all file path parameters for the pipeline to the list below
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.fasta, params.taxdump, params.busco.download_dir, params.uniprot ]
+def checkPathParamList = [ params.input, params.multiqc_config, params.fasta, params.settings.taxdump, params.busco.download_dir, params.uniprot ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 // Check mandatory parameters
@@ -19,7 +19,7 @@ if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input sample
 if (params.fasta && params.accession) { ch_fasta = Channel.of([ [ 'id': params.accession ], params.fasta ]).collect() } else { exit 1, 'Genome fasta file and accession must be specified!' }
 if (params.taxon) { ch_taxon = Channel.of(params.taxon) } else { exit 1, 'NCBI Taxon ID not specified!' }
 if (params.uniprot) { ch_uniprot = file(params.uniprot) } else { exit 1, 'Diamond BLASTp database not specified!' }
-if (params.taxdump) { ch_taxdump = file(params.taxdump) } else { exit 1, 'NCBI Taxonomy database not specified!' }
+if (params.settings && params.settings.taxdump) { ch_taxdump = file(params.settings.taxdump) } else { exit 1, 'NCBI Taxonomy database not specified!' }
 
 // Create channel for optional parameters
 if (params.busco && params.busco.download_dir) { ch_busco_db = Channel.fromPath(params.busco.download_dir) } else { ch_busco_db = Channel.empty() }

--- a/workflows/blobtoolkit.nf
+++ b/workflows/blobtoolkit.nf
@@ -11,13 +11,13 @@ WorkflowBlobtoolkit.initialise(params, log)
 
 // Add all file path parameters for the pipeline to the list below
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.fasta, params.settings.taxdump, params.busco.download_dir, params.uniprot ]
+def checkPathParamList = [ params.input, params.multiqc_config, params.assembly.file, params.settings.taxdump, params.busco.download_dir, params.uniprot ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
-if (params.fasta && params.accession) { ch_fasta = Channel.of([ [ 'id': params.accession ], params.fasta ]).collect() } else { exit 1, 'Genome fasta file and accession must be specified!' }
-if (params.taxon) { ch_taxon = Channel.of(params.taxon) } else { exit 1, 'NCBI Taxon ID not specified!' }
+if (params.assembly && params.assembly.file && params.assembly.accession) { ch_fasta = Channel.of([ [ 'id': params.assembly.accession ], params.assembly.file ]).collect() } else { exit 1, 'Genome fasta file and accession must be specified!' }
+if (params.taxon && params.taxon.name) { ch_taxon = Channel.of(params.taxon.name) } else { exit 1, 'NCBI Taxon ID not specified!' }
 if (params.uniprot) { ch_uniprot = file(params.uniprot) } else { exit 1, 'Diamond BLASTp database not specified!' }
 if (params.settings && params.settings.taxdump) { ch_taxdump = file(params.settings.taxdump) } else { exit 1, 'NCBI Taxonomy database not specified!' }
 
@@ -86,7 +86,7 @@ workflow BLOBTOOLKIT {
     //
     // MODULE: Decompress FASTA file if needed
     //
-    if ( params.fasta.endsWith('.gz') ) {
+    if ( params.assembly.file.endsWith('.gz') ) {
         ch_genome   = GUNZIP ( ch_fasta ).gunzip
         ch_versions = ch_versions.mix ( GUNZIP.out.versions.first() )
     } else {


### PR DESCRIPTION
Hi,

I've been wondering a lot how to reconcile the parameters that the Nextflow processes use (typically by setting `params.*` and `ext.args`) and the BTK Yaml file. To avoid redundancy, I think there should be a single source.

Here is a proof on concept for using a BTK-style Yaml file as the main configuration mechanism (through Nextflow's native `-params-file`), from which the pipeline takes all its parameters by setting `ext.args`.

This is a _draft_ PR and should remain that way for now. The unit test seems to work, but I've removed some parameter validation and the code would likely crash if some key parameters are missing.
I didn't try defining the reads in the Yaml file, so there is still a CSV sample sheet, but that would be the next natural step. Then, to complete the Yaml file that goes into the blobdir, we'd still have to add the software versions (can be done by adding a process that takes `ch_versions`), and some other genome metadata stuff I think.

It's just one way of doing. Alternatively the config file could be given through an option like `--btk-config /path/to/yaml` which is parsed and flown into the jobs through `meta` ?

Comments welcome 😄 


<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/blobtoolkit/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
