### PR TITLE
More bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ General tidy up of the configuration and the pipeline
 - Increased the resources for blastn
 - Removed some options that were not used or not needed
 - All relevant outputs are now copied to the output directory
+- Fixed some blast parameters to match the behaviour of the Snakemake pipeline
 
 ### Parameters
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -105,9 +105,11 @@ process {
     }
 
     withName: "BLAST_BLASTN" {
-        cpus   = { check_max( 24    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 1.GB * task.attempt, 'memory' ) }
-        time   = { check_max( 12.h  * task.attempt, 'time'    ) }
+        // Most jobs complete quickly but some need a lot longer. For those outliers,
+        // the CPU usage remains usually low, often nearing a single CPU
+        cpus   = { check_max( 6    -            (task.attempt-1), 'cpus'   ) }
+        memory = { check_max( 1.GB * Math.pow(4, task.attempt-1), 'memory' ) }
+        time   = { check_max( 10.h * Math.pow(4, task.attempt-1), 'time'   ) }
     }
 
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {

--- a/conf/base.config
+++ b/conf/base.config
@@ -106,7 +106,7 @@ process {
 
     withName: "BLAST_BLASTN" {
         cpus   = { check_max( 24    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 100.MB * task.attempt, 'memory' ) }
+        memory = { check_max( 1.GB * task.attempt, 'memory' ) }
         time   = { check_max( 12.h  * task.attempt, 'time'    ) }
     }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -105,6 +105,10 @@ process {
     }
 
     withName: "BLAST_BLASTN" {
+
+        // There are blast failures we don't know how to fix. Just ignore for now
+        errorStrategy = { task.exitStatus in ((130..145) + 104) ? (task.attempt == process.maxRetries ? 'ignore' : 'retry') : 'finish' }
+
         // Most jobs complete quickly but some need a lot longer. For those outliers,
         // the CPU usage remains usually low, often nearing a single CPU
         cpus   = { check_max( 6    -            (task.attempt-1), 'cpus'   ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -138,7 +138,7 @@ process {
     }
 
     withName: "BLAST_BLASTN" {
-        ext.args = "-outfmt '6 qseqid staxids bitscore std' -max_target_seqs 10 -max_hsps 1 -evalue 1.0e-10 -lcase_masking -dust '20 64 1'"
+        ext.args = "-task megablast -outfmt '6 qseqid staxids bitscore std' -max_target_seqs 10 -max_hsps 1 -evalue 1.0e-10 -lcase_masking -dust '20 64 1'"
     }
 
     withName: "CUSTOM_DUMPSOFTWAREVERSIONS" {

--- a/modules.json
+++ b/modules.json
@@ -30,12 +30,14 @@
                     "diamond/blastp": {
                         "branch": "master",
                         "git_sha": "b29f6beb86d1d24d680277fb1a3f4de7b8b8a92c",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/diamond/blastp/diamond-blastp.diff"
                     },
                     "diamond/blastx": {
                         "branch": "master",
                         "git_sha": "b29f6beb86d1d24d680277fb1a3f4de7b8b8a92c",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/diamond/blastx/diamond-blastx.diff"
                     },
                     "fastawindows": {
                         "branch": "master",

--- a/modules/nf-core/blast/blastn/blast-blastn.diff
+++ b/modules/nf-core/blast/blastn/blast-blastn.diff
@@ -16,21 +16,31 @@ Changes in module 'nf-core/blast/blastn'
  
      output:
      tuple val(meta), path('*.txt'), emit: txt
-@@ -23,6 +23,7 @@
+@@ -23,6 +23,8 @@
      def prefix = task.ext.prefix ?: "${meta.id}"
      def is_compressed = fasta.getExtension() == "gz" ? true : false
      def fasta_name = is_compressed ? fasta.getBaseName() : fasta
 +    def exclude_taxon = taxid ? "-negative_taxids ${taxid}" : ''
++    def command_epilog = taxid ? "|| true" : ''
  
      """
      if [ "${is_compressed}" == "true" ]; then
-@@ -39,6 +40,7 @@
+@@ -39,8 +41,15 @@
          -num_threads ${task.cpus} \\
          -db \$DB \\
          -query ${fasta_name} \\
 +        ${exclude_taxon} \\
          ${args} \\
-         -out ${prefix}.txt
+-        -out ${prefix}.txt
++        -out ${prefix}.txt \\
++        2> >( tee "${prefix}.error.log" >&2 ) $command_epilog
++
++    if [[ -s "${prefix}.error.log" ]]
++    then
++        grep -qF 'BLAST Database error: Taxonomy ID(s) not found.Taxonomy ID(s) not found' "${prefix}.error.log"
++    fi
  
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
 
 ************************************************************

--- a/modules/nf-core/blast/blastn/main.nf
+++ b/modules/nf-core/blast/blastn/main.nf
@@ -24,6 +24,7 @@ process BLAST_BLASTN {
     def is_compressed = fasta.getExtension() == "gz" ? true : false
     def fasta_name = is_compressed ? fasta.getBaseName() : fasta
     def exclude_taxon = taxid ? "-negative_taxids ${taxid}" : ''
+    def command_epilog = taxid ? "|| true" : ''
 
     """
     if [ "${is_compressed}" == "true" ]; then
@@ -42,7 +43,13 @@ process BLAST_BLASTN {
         -query ${fasta_name} \\
         ${exclude_taxon} \\
         ${args} \\
-        -out ${prefix}.txt
+        -out ${prefix}.txt \\
+        2> >( tee "${prefix}.error.log" >&2 ) $command_epilog
+
+    if [[ -s "${prefix}.error.log" ]]
+    then
+        grep -qF 'BLAST Database error: Taxonomy ID(s) not found.Taxonomy ID(s) not found' "${prefix}.error.log"
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/diamond/blastp/diamond-blastp.diff
+++ b/modules/nf-core/diamond/blastp/diamond-blastp.diff
@@ -1,0 +1,29 @@
+Changes in module 'nf-core/diamond/blastp'
+--- modules/nf-core/diamond/blastp/main.nf
++++ modules/nf-core/diamond/blastp/main.nf
+@@ -12,6 +12,7 @@
+     tuple val(meta2), path(db)
+     val out_ext
+     val blast_columns
++    val taxid
+ 
+     output:
+     tuple val(meta), path('*.blast'), optional: true, emit: blast
+@@ -32,6 +33,7 @@
+     def is_compressed = fasta.getExtension() == "gz" ? true : false
+     def fasta_name = is_compressed ? fasta.getBaseName() : fasta
+     def columns = blast_columns ? "${blast_columns}" : ''
++    def exclude_taxon = taxid ? "--taxon-exclude ${taxid}" : ''
+     switch ( out_ext ) {
+         case "blast": outfmt = 0; break
+         case "xml": outfmt = 5; break
+@@ -59,6 +61,7 @@
+         --db \$DB \\
+         --query ${fasta_name} \\
+         --outfmt ${outfmt} ${columns} \\
++        ${exclude_taxon} \\
+         ${args} \\
+         --out ${prefix}.${out_ext}
+ 
+
+************************************************************

--- a/modules/nf-core/diamond/blastp/main.nf
+++ b/modules/nf-core/diamond/blastp/main.nf
@@ -12,6 +12,7 @@ process DIAMOND_BLASTP {
     tuple val(meta2), path(db)
     val out_ext
     val blast_columns
+    val taxid
 
     output:
     tuple val(meta), path('*.blast'), optional: true, emit: blast
@@ -32,6 +33,7 @@ process DIAMOND_BLASTP {
     def is_compressed = fasta.getExtension() == "gz" ? true : false
     def fasta_name = is_compressed ? fasta.getBaseName() : fasta
     def columns = blast_columns ? "${blast_columns}" : ''
+    def exclude_taxon = taxid ? "--taxon-exclude ${taxid}" : ''
     switch ( out_ext ) {
         case "blast": outfmt = 0; break
         case "xml": outfmt = 5; break
@@ -59,6 +61,7 @@ process DIAMOND_BLASTP {
         --db \$DB \\
         --query ${fasta_name} \\
         --outfmt ${outfmt} ${columns} \\
+        ${exclude_taxon} \\
         ${args} \\
         --out ${prefix}.${out_ext}
 

--- a/modules/nf-core/diamond/blastx/diamond-blastx.diff
+++ b/modules/nf-core/diamond/blastx/diamond-blastx.diff
@@ -1,0 +1,29 @@
+Changes in module 'nf-core/diamond/blastx'
+--- modules/nf-core/diamond/blastx/main.nf
++++ modules/nf-core/diamond/blastx/main.nf
+@@ -12,6 +12,7 @@
+     tuple val(meta2), path(db)
+     val out_ext
+     val blast_columns
++    val taxid
+ 
+     output:
+     tuple val(meta), path('*.blast'), optional: true, emit: blast
+@@ -33,6 +34,7 @@
+     def is_compressed = fasta.getExtension() == "gz" ? true : false
+     def fasta_name = is_compressed ? fasta.getBaseName() : fasta
+     def columns = blast_columns ? "${blast_columns}" : ''
++    def exclude_taxon = taxid ? "--taxon-exclude ${taxid}" : ''
+     switch ( out_ext ) {
+         case "blast": outfmt = 0; break
+         case "xml": outfmt = 5; break
+@@ -60,6 +62,7 @@
+         --db \$DB \\
+         --query ${fasta_name} \\
+         --outfmt ${outfmt} ${columns} \\
++        ${exclude_taxon} \\
+         ${args} \\
+         --out ${prefix}.${out_ext} \\
+         --log
+
+************************************************************

--- a/modules/nf-core/diamond/blastx/main.nf
+++ b/modules/nf-core/diamond/blastx/main.nf
@@ -12,6 +12,7 @@ process DIAMOND_BLASTX {
     tuple val(meta2), path(db)
     val out_ext
     val blast_columns
+    val taxid
 
     output:
     tuple val(meta), path('*.blast'), optional: true, emit: blast
@@ -33,6 +34,7 @@ process DIAMOND_BLASTX {
     def is_compressed = fasta.getExtension() == "gz" ? true : false
     def fasta_name = is_compressed ? fasta.getBaseName() : fasta
     def columns = blast_columns ? "${blast_columns}" : ''
+    def exclude_taxon = taxid ? "--taxon-exclude ${taxid}" : ''
     switch ( out_ext ) {
         case "blast": outfmt = 0; break
         case "xml": outfmt = 5; break
@@ -60,6 +62,7 @@ process DIAMOND_BLASTX {
         --db \$DB \\
         --query ${fasta_name} \\
         --outfmt ${outfmt} ${columns} \\
+        ${exclude_taxon} \\
         ${args} \\
         --out ${prefix}.${out_ext} \\
         --log

--- a/subworkflows/local/busco_diamond_blastp.nf
+++ b/subworkflows/local/busco_diamond_blastp.nf
@@ -39,6 +39,7 @@ workflow BUSCO_DIAMOND {
     | transpose()
     | filter { rank,id -> rank =~ /species/ }
     | map { rank, id -> id}
+    | first
     | set { ch_taxid }
 
 
@@ -116,7 +117,7 @@ workflow BUSCO_DIAMOND {
     // Hardcoded to match the format expected by blobtools
     def outext = 'txt'
     def cols   = 'qseqid staxids bitscore qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore'
-    DIAMOND_BLASTP ( ch_busco_genes, blastp, outext, cols )
+    DIAMOND_BLASTP ( ch_busco_genes, blastp, outext, cols, ch_taxid )
     ch_versions = ch_versions.mix ( DIAMOND_BLASTP.out.versions.first() )
 
 

--- a/subworkflows/local/run_blastx.nf
+++ b/subworkflows/local/run_blastx.nf
@@ -11,6 +11,7 @@ workflow RUN_BLASTX {
     fasta      // channel: [ val(meta), path(fasta) ]
     table      // channel: [ val(meta), path(busco_table) ]
     blastx     // channel: [ val(meta), path(blastx_db) ]
+    taxon_id   // channel: val(taxon_id)
 
 
     main:
@@ -30,7 +31,7 @@ workflow RUN_BLASTX {
     // Hardocded to match the format expected by blobtools
     def outext = 'txt'
     def cols   = 'qseqid staxids bitscore qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore'
-    DIAMOND_BLASTX ( BLOBTOOLKIT_CHUNK.out.chunks, blastx, outext, cols)
+    DIAMOND_BLASTX ( BLOBTOOLKIT_CHUNK.out.chunks, blastx, outext, cols, taxon_id )
     ch_versions = ch_versions.mix ( DIAMOND_BLASTX.out.versions.first() )
 
 

--- a/workflows/blobtoolkit.nf
+++ b/workflows/blobtoolkit.nf
@@ -140,6 +140,7 @@ workflow BLOBTOOLKIT {
         PREPARE_GENOME.out.genome,
         BUSCO_DIAMOND.out.first_table,
         ch_blastx,
+        BUSCO_DIAMOND.out.taxon_id,
     )
     ch_versions = ch_versions.mix ( RUN_BLASTX.out.versions )
 
@@ -151,7 +152,7 @@ workflow BLOBTOOLKIT {
         RUN_BLASTX.out.blastx_out,
         PREPARE_GENOME.out.genome,
         ch_blastn,
-        BUSCO_DIAMOND.out.taxon_id
+        BUSCO_DIAMOND.out.taxon_id,
     )
 
     //


### PR DESCRIPTION
Last set of bugfixes before the v0.5 release

- Added the missing "megablast" parameter
- Added the missing `--taxon-exclude` in Diamond blast searches
- Ignore warnings that the requested taxon id is not in the NT database
- Increased resources for blastn, now following this model

| Attempt | CPUs | Memory | Maximum runtime | Queue (Sanger) |
|---|---|---|---|---|
| 1 | 6 |  1 GB  |  10h | normal |
| 2 | 5 |  4 GB  |  40h | long |
| 3 | 4 | 16 GB  | 160h | week |
| 4 | 3 | 64 GB  | 640h | basement |
| 5 | 2 | 256 GB | 2,560h | basement |

(the number of CPUs decreases because long-running jobs are typically stuck on a sequence and don't use more than 150% CPU on average.)

I've tested the branch on the three genomes from TOLIT-2257 in `/lustre/scratch123/tol/teams/tolit/users/mm49/nextflow/btk/prod`

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
