### PR TITLE
Skip blastn if there are no chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[0.5.1](https://github.com/sanger-tol/blobtoolkit/releases/tag/0.5.1)] – Snorlax (patch 1) – [2024-08-15]
+
+### Enhancements & fixes
+
+- Bugfix: skip BLASTN if there are no chunks to align
+
 ## [[0.5.0](https://github.com/sanger-tol/blobtoolkit/releases/tag/0.5.0)] – Snorlax – [2024-07-31]
 
 General tidy up of the configuration and the pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[0.5.1](https://github.com/sanger-tol/blobtoolkit/releases/tag/0.5.1)] – Snorlax (patch 1) – [2024-08-15]
+## [[0.5.1](https://github.com/sanger-tol/blobtoolkit/releases/tag/0.5.1)] – Snorlax (patch 1) – [2024-08-22]
 
 ### Enhancements & fixes
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -243,7 +243,7 @@ manifest {
     description     = """Quality assessment of genome assemblies"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.5.0'
+    version         = '0.5.1'
     doi             = '10.5281/zenodo.7949058'
 }
 


### PR DESCRIPTION
BLASTN complains if the query file is empty, so we need to make sure we skip BLASTN if there are no chunks.
Some filtering is already meant to happen in [SEQTK_SUBSEQ](https://github.com/sanger-tol/blobtoolkit/blob/0.5.0/subworkflows/local/run_blastn.nf#L34) but we found in production (`/lustre/scratch122/tol/scratch/prefect_prod/f8cf341f-5575-4dfb-8ada-b6ca6479c8e1/e155aa26-984d-4c29-8164-39eaf6a1ed46/`) that it's not sufficient because BLOBTOOLKIT_CHUNK further excludes masked regions.

I tested this by temporarily removing the SEQTK_SUBSEQ filter. Then the new filter should kick in.

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
