### PR TITLE
bugfix when running the pipeline on uncompressed databases

### DIFF
--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -48,7 +48,7 @@ workflow INPUT_CHECK {
     ch_databases = UNTAR.out.untar.concat( ch_dbs_for_untar.skip )
         .map { meta, db -> [ meta + [id: db.baseName], db] }
         .map { db_meta, db_path ->
-            if (db_meta.type in ["blastp", "blastx"]) {
+            if (db_meta.type in ["blastp", "blastx"] && db_path.isDirectory()) {
                 [db_meta, file(db_path.toString() + "/${db_path.name}", checkIfExists: true)]
             } else {
                 [db_meta, db_path]


### PR DESCRIPTION
I made this one happen when suggested a change that removed the `isDirectory` check.

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
