### PR TITLE
Support an empty samplesheet and more read checks

### DIFF
--- a/bin/generate_config.py
+++ b/bin/generate_config.py
@@ -60,7 +60,7 @@ def parse_args(args=None):
         pass
     elif args.read_id and args.read_type and args.read_layout and args.read_path:
         # All read arguments passed
-        if set([len(args.read_id), len(args.read_type), len(args.read_layout), len(args.read_path)]) != 1:
+        if len(set([len(args.read_id), len(args.read_type), len(args.read_layout), len(args.read_path)])) != 1:
             print(f"The --read_id, --read_type, --read_layout, and --read_path, must be passed the same number of times", file=sys.stderr)
             sys.exit(1)
     else:

--- a/bin/generate_config.py
+++ b/bin/generate_config.py
@@ -53,8 +53,21 @@ def parse_args(args=None):
     parser.add_argument("--taxdump", help="Path to the taxonomy database", required=True)
     parser.add_argument("--precomputed_busco", action="append", help="Path to precomputed BUSCO outputs", required=False)
     parser.add_argument("--version", action="version", version="%(prog)s 2.0")
-    return parser.parse_args(args)
+    args = parser.parse_args(args)
 
+    if not args.read_id and not args.read_type and not args.read_layout and not args.read_path:
+        # All read arguments skipped, OK
+        pass
+    elif args.read_id and args.read_type and args.read_layout and args.read_path:
+        # All read arguments passed
+        if set([len(args.read_id), len(args.read_type), len(args.read_layout), len(args.read_path)]) != 1:
+            print(f"The --read_id, --read_type, --read_layout, and --read_path, must be passed the same number of times", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(f"The --read_id, --read_type, --read_layout, and --read_path, must be passed the same number of times", file=sys.stderr)
+        sys.exit(1)
+
+    return args
 
 def make_dir(path):
     if len(path) > 0:
@@ -360,7 +373,7 @@ def main(args=None):
     if sequence_report:
         print_tsvs(args.output_prefix, sequence_report)
 
-    reads = zip(args.read_id, args.read_type, args.read_layout, args.read_path)
+    reads = zip(args.read_id, args.read_type, args.read_layout, args.read_path) if args.read_id else []
 
     print_yaml(
         f"{args.output_prefix}.yaml",


### PR DESCRIPTION
Not sure how often it may happen, but at least for testing I often run the pipeline without any reads. The change here is actually not to just allow no reads, but also to ensure that all read parameters are consistently passed.

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
