### PR TITLE
Update modules.config

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -105,11 +105,11 @@ process {
     }
 
     withName: "DIAMOND_BLASTP" {
-        ext.args = "--evalue 1.0e-25  --max-target-seqs 10 --max-hsps 1"
+        ext.args = "--evalue 1.0e-25  --max-target-seqs 10 --max-hsps 1 --tmpdir blastp_tmp"
     }
 
     withName: "DIAMOND_BLASTX" {
-        ext.args = "--evalue 1.0e-25  --max-target-seqs 10 --max-hsps 1"
+        ext.args = "--evalue 1.0e-25  --max-target-seqs 10 --max-hsps 1 --tmpdir blastx_tmp"
     }
 
     withName: "BLOBTK_DEPTH" {


### PR DESCRIPTION
Add tmpdir arg to diamond_blast* modules

Came across an issue where pipeline is struggling to access tmp and has killed a number of production runs.