### PR TITLE
Added an option to control the revision number of the blobDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[0.11.0](https://github.com/sanger-tol/blobtoolkit/releases/tag/0.11.0)] – – [2026-04-]
 
+### Enhancements & fixes
+
+- Added an option to control the version ("revision") of the blobDir.
+  Use when rerunning the pipeline on an assembly.
+
+### Parameters
+
+| Old parameter | New parameter |
+| ------------- | ------------- |
+|               | --revision    |
+
 ### Software dependencies
 
 Note, since the pipeline is using Nextflow DSL2, each process will be run with its own [Biocontainer](https://biocontainers.pro/#/registry). This means that on occasion it is entirely possible for the pipeline to be using different versions of the same tool. However, the overall software dependency changes compared to the last release have been listed below for reference. Only `Docker` or `Singularity` containers are supported, `conda` is not supported.

--- a/bin/generate_config.py
+++ b/bin/generate_config.py
@@ -56,6 +56,7 @@ def parse_args(args=None):
     parser.add_argument("--read_type", action="append", help="Type of a read set")
     parser.add_argument("--read_layout", action="append", help="Layout of a read set")
     parser.add_argument("--read_path", action="append", help="Path of a read set")
+    parser.add_argument("--revision", type=int, help="Requested rvision (version) of the output blobDir")
     parser.add_argument("--blastp", help="Path to the blastp database", required=True)
     parser.add_argument("--blastx", help="Path to the blastx database", required=True)
     parser.add_argument("--blastn", help="Path to the blastn database", required=True)
@@ -261,6 +262,7 @@ def print_yaml(
     taxon_info: TaxonInfo,
     classification: typing.Dict[str, str],
     reads,
+    revision,
     blastp,
     blastx,
     blastn,
@@ -272,7 +274,7 @@ def print_yaml(
             "paired": [],
             "single": [],
         },
-        "revision": 1,
+        "revision": revision,
         "settings": {
             "blast_chunk": 100000,
             "blast_max_chunks": 10,
@@ -390,6 +392,7 @@ def main(args=None):
         taxon_info,
         classification,
         reads,
+        args.revision,
         args.blastp,
         args.blastx,
         args.blastn,

--- a/bin/generate_config.py
+++ b/bin/generate_config.py
@@ -56,7 +56,7 @@ def parse_args(args=None):
     parser.add_argument("--read_type", action="append", help="Type of a read set")
     parser.add_argument("--read_layout", action="append", help="Layout of a read set")
     parser.add_argument("--read_path", action="append", help="Path of a read set")
-    parser.add_argument("--revision", type=int, help="Requested rvision (version) of the output blobDir")
+    parser.add_argument("--revision", type=int, help="Requested revision (version) of the output blobDir")
     parser.add_argument("--blastp", help="Path to the blastp database", required=True)
     parser.add_argument("--blastx", help="Path to the blastx database", required=True)
     parser.add_argument("--blastn", help="Path to the blastn database", required=True)

--- a/modules/local/generate_config.nf
+++ b/modules/local/generate_config.nf
@@ -42,6 +42,7 @@ process GENERATE_CONFIG {
         $accession_params \\
         --nt $blastn \\
         $input_reads \\
+        --revision ${params.revision} \\
         $input_databases \\
         --output_prefix ${prefix} \\
         $args

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ params {
     taxon                      = null
 
     // Output options
+    revision                   = 1
     image_format               = 'png'
 
     // Databases and related options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -60,6 +60,13 @@
                     "description": "Directory containing precomputed BUSCO results (each named as `run_{lineage}_odbxx`), which can be supplied to skip running BUSCO in the pipeline.",
                     "fa_icon": "fas fa-folder-open"
                 },
+                "revision": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "blobDir version number (defaults to 1). Set to a higher value when recomputing the blobDir of an assembly.",
+                    "fa_icon": "fas fa-1",
+                    "minimum": 1
+                },
                 "image_format": {
                     "type": "string",
                     "enum": ["png", "svg"],


### PR DESCRIPTION
As simple as it gets ! New parameter registered in `nextflow.config` and `nextflow_schema.json`.

It's currently directly used in `modules/local/generate_config.nf` like `params.accesion` – against Nextflow guidelines !
I'd like to keep it this way for now and address accessing all `params.*` in another PR 

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
