### PR TITLE
min_window_length

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -147,8 +147,7 @@ process {
     }
 
     withName: "BLOBTOOLKIT_WINDOWSTATS" {
-        // overridden in test profiles, see below
-        ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000"
+        ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 100"
     }
 
     withName: "BLOBTOOLKIT_CREATEBLOBDIR" {
@@ -208,36 +207,4 @@ process {
         ]
     }
 
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Extra profiles defined to override some of the above parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Importantly, these profiles *cannot* be defined in the main `nextflow.config`,
-    otherwise they would be loaded _before_ this `conf/modules.config`.
-----------------------------------------------------------------------------------------
-*/
-profiles {
-    test {
-        process {
-            withName: "BLOBTOOLKIT_WINDOWSTATS" {
-                ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 78850"
-            }
-        }
-    }
-    test_nobusco {
-        process {
-            withName: "BLOBTOOLKIT_WINDOWSTATS" {
-                ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 78850"
-            }
-        }
-    }
-    test_raw {
-        process {
-            withName: "BLOBTOOLKIT_WINDOWSTATS" {
-                ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 78850"
-            }
-        }
-    }
 }


### PR DESCRIPTION
The full test [failed](https://cloud.seqera.io/orgs/sanger-tol/workspaces/github-ci/watch/5if37WzuFMLJkB/logs) over the weekend with the same "no entry found for key" blobtk error 134 as in #230

Rather than introducing a pipeline parameter, I propose setting a ridiculously small value that ought to work on all genomes.
I can confirm it works on the full test. I'll start the sentinel test hopefully later today.

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
