### PR TITLE
Blastn fix

### DIFF
--- a/modules/nf-core/blast/blastn/blast-blastn.diff
+++ b/modules/nf-core/blast/blastn/blast-blastn.diff
@@ -27,7 +27,7 @@ Changes in 'blast/blastn/main.nf':
  
      """
      if [ "${is_compressed}" == "true" ]; then
-@@ -40,21 +40,37 @@
+@@ -40,21 +40,48 @@
  
      export BLASTDB=${db}
  
@@ -45,6 +45,17 @@ Changes in 'blast/blastn/main.nf':
      echo Using \$DB
  
 -    blastn \\
++    if [ -n "${taxidlist_cmd}${taxids_cmd}" ]; then
++        # Symlink the tax* files (needed for -taxid options to work)
++        for file in taxdb.btd taxdb.bti taxonomy4blast.sqlite3; do
++            if [ ! -f ${db}/\$file ]; then
++                echo "Error: \$file not found in ${db}"
++                exit 1
++            fi
++            ln -s ${db}/\$file .
++        done
++    fi
++
 +    timeout 11.9h blastn \\
          -num_threads ${task.cpus} \\
          -db \$DB \\

--- a/modules/nf-core/blast/blastn/main.nf
+++ b/modules/nf-core/blast/blastn/main.nf
@@ -57,7 +57,7 @@ process BLAST_BLASTN {
                 echo "Error: \$file not found in ${db}"
                 exit 1
             fi
-            ln -s ${db}/\$file .
+            ln -sf ${db}/\$file .
         done
     fi
 

--- a/modules/nf-core/blast/blastn/main.nf
+++ b/modules/nf-core/blast/blastn/main.nf
@@ -50,6 +50,17 @@ process BLAST_BLASTN {
     fi
     echo Using \$DB
 
+    if [ -n "${taxidlist_cmd}${taxids_cmd}" ]; then
+        # Symlink the tax* files (needed for -taxid options to work)
+        for file in taxdb.btd taxdb.bti taxonomy4blast.sqlite3; do
+            if [ ! -f ${db}/\$file ]; then
+                echo "Error: \$file not found in ${db}"
+                exit 1
+            fi
+            ln -s ${db}/\$file .
+        done
+    fi
+
     timeout 11.9h blastn \\
         -num_threads ${task.cpus} \\
         -db \$DB \\


### PR DESCRIPTION
Here I reintroduce the taxonomy db symlinks that turn out to be necessary.

I think we didn't notice before because:
 - the `test` profile doesn't have any blastn hits (blastn only _errors_ about the db missing if there's a hit, otherwise it's only a warning)
 - the `test_full` profile doesn't even run blastn

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
