### PR TITLE
Min window length - final attempt

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -147,8 +147,8 @@ process {
     }
 
     withName: "BLOBTOOLKIT_WINDOWSTATS" {
-        // overridden in test profiles, see below
-        ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000"
+        // --min-window-length 10000 caters for sequences as small as 1 Mbp
+        ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 10000"
     }
 
     withName: "BLOBTOOLKIT_CREATEBLOBDIR" {
@@ -208,36 +208,4 @@ process {
         ]
     }
 
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Extra profiles defined to override some of the above parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Importantly, these profiles *cannot* be defined in the main `nextflow.config`,
-    otherwise they would be loaded _before_ this `conf/modules.config`.
-----------------------------------------------------------------------------------------
-*/
-profiles {
-    test {
-        process {
-            withName: "BLOBTOOLKIT_WINDOWSTATS" {
-                ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 78850"
-            }
-        }
-    }
-    test_nobusco {
-        process {
-            withName: "BLOBTOOLKIT_WINDOWSTATS" {
-                ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 78850"
-            }
-        }
-    }
-    test_raw {
-        process {
-            withName: "BLOBTOOLKIT_WINDOWSTATS" {
-                ext.args = "--window 0.1 --window 0.01 --window 1 --window 100000 --window 1000000 --min-window-length 78850"
-            }
-        }
-    }
 }

--- a/subworkflows/local/view.nf
+++ b/subworkflows/local/view.nf
@@ -27,7 +27,7 @@ workflow VIEW {
         ],
         [
             name: "grid",
-            args: "-v blob --shape grid -w 0.01 -x position"
+            args: "-v blob --shape grid -x position"
         ],
         [
             name: "cumulative",
@@ -41,6 +41,12 @@ workflow VIEW {
 
     ch_blobtk_plot_input = blobdir
         .combine(plots)
+        // Only add "-w 0.01" to the grid paramters if there are such windows available
+        .map { meta, local, btk_args ->
+            ((btk_args.name == "grid") && file(local.toUriString() + "/length_windows_0.01.json").exists())
+            ? [meta, local, [name: "grid", args: btk_args.args + " -w 0.01"]]
+            : [meta, local, btk_args]
+        }
         .multiMap { meta, local, btk_args ->
             fasta: [meta, []]
             local_path: local


### PR DESCRIPTION
Hopefully this should be the last attempt

Following the email conversation with Rich, I've set `--min-window-length` to 10000 by default, which is small enough for the `test` and `test_full` profiles. No need for profile-specific settings.

To cater with even smaller genomes / sequences, I check the presence of the `length_windows_0.01.json` file in the blobdir, and only add `-w 0.01` if it is present.

<!--
# sanger-tol/blobtoolkit pull request

Many thanks for contributing to sanger-tol/blobtoolkit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/blobtoolkit/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
